### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dominikpuz  @xMOROx @erizee 


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns several files to their proper team for ownership.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1): Added `@dominikpuz`, `@xMOROx`, and `@erizee` as code owners.