### PR TITLE
Pes buffer

### DIFF
--- a/common/src/mpegts/adaptation_field.rs
+++ b/common/src/mpegts/adaptation_field.rs
@@ -204,7 +204,6 @@ impl AdaptationFieldExtension {
 
         if af_descriptor_not_present_float && index < buffer.len() {
             extension.reserved = Some(buffer[index]);
-            index += 1;
         }
 
         Some(extension)

--- a/common/src/mpegts/header.rs
+++ b/common/src/mpegts/header.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 pub struct Header {
     pub transport_error_indicator: bool,
     pub payload_unit_start_indicator: bool,
@@ -11,8 +11,9 @@ pub struct Header {
     pub continuity_counter: u8,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum PIDTable {
+    #[default]
     ProgramAssociation,
     ConditionalAccess,
     TransportStreamDescription,
@@ -22,14 +23,16 @@ pub enum PIDTable {
     NullPacket,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 pub enum TransportScramblingControl {
+    #[default]
     NotScrambled,
     UserDefined(u8),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
 pub enum AdaptationFieldControl {
+    #[default]
     PayloadOnly,
     AdaptationFieldOnly,
     AdaptationFieldAndPaylod,

--- a/common/src/mpegts/pes/fragmentary_pes.rs
+++ b/common/src/mpegts/pes/fragmentary_pes.rs
@@ -1,8 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct FragmentaryPes {
-    pub packet_start_code_prefix: u32,
-    pub stream_id: u8,
-    pub pes_packet_length: u16,
-}

--- a/common/src/mpegts/pes/pes_buffer.rs
+++ b/common/src/mpegts/pes/pes_buffer.rs
@@ -1,6 +1,8 @@
-use crate::mpegts::MpegtsFragment;
+#[cfg(test)]
+mod tests;
 
 use super::PacketizedElementaryStream;
+use crate::mpegts::MpegtsFragment;
 
 pub struct PesPacketPayload {
     pub data: Vec<u8>,

--- a/common/src/mpegts/pes/pes_buffer.rs
+++ b/common/src/mpegts/pes/pes_buffer.rs
@@ -3,7 +3,8 @@ mod tests;
 
 use super::PacketizedElementaryStream;
 use crate::mpegts::MpegtsFragment;
-
+use serde::{Deserialize, Serialize};
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct PesPacketPayload {
     pub data: Vec<u8>,
     pub is_completable: bool,
@@ -61,6 +62,7 @@ impl PesPacketPayload {
         self.data.extend_from_slice(payload);
     }
 }
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct PesBuffer {
     payload: PesPacketPayload,
 }
@@ -105,5 +107,25 @@ impl PesBuffer {
         let data = self.payload.get_data();
         let pes = PacketizedElementaryStream::build(data);
         pes
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.payload.is_complete()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.payload.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.payload.clear();
+    }
+
+    pub fn get_payload(&self) -> &PesPacketPayload {
+        &self.payload
+    }
+
+    pub fn get_payload_mut(&mut self) -> &mut PesPacketPayload {
+        &mut self.payload
     }
 }

--- a/common/src/mpegts/pes/pes_buffer/tests.rs
+++ b/common/src/mpegts/pes/pes_buffer/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use crate::mpegts::{Header, RawPayload};
+
+#[test]
+fn test_pes_packet_payload_new() {
+    let payload = PesPacketPayload::new();
+    assert!(payload.data.is_empty());
+    assert!(!payload.is_completable);
+    assert_eq!(payload.packet_length, 0);
+}
+
+#[test]
+fn test_pes_packet_payload_set_get_length() {
+    let mut payload = PesPacketPayload::new();
+    payload.set_packet_length(100);
+    assert_eq!(payload.get_packet_length(), 100);
+}
+
+#[test]
+fn test_pes_packet_payload_completable() {
+    let mut payload = PesPacketPayload::new();
+    assert!(!payload.is_completable());
+    payload.set_completable(true);
+    assert!(payload.is_completable());
+}
+
+#[test]
+fn test_pes_packet_payload_data_operations() {
+    let mut payload = PesPacketPayload::new();
+    assert!(payload.is_empty());
+
+    payload.append(&[1, 2, 3]);
+    assert_eq!(payload.get_data(), &[1, 2, 3]);
+
+    payload.get_data_mut().push(4);
+    assert_eq!(payload.get_data(), &[1, 2, 3, 4]);
+}
+
+#[test]
+fn test_pes_packet_payload_is_complete() {
+    let mut payload = PesPacketPayload::new();
+    assert!(!payload.is_complete());
+
+    payload.set_packet_length(4);
+    payload.append(&[1, 2, 3, 4]);
+    assert!(!payload.is_complete());
+
+    payload.set_completable(true);
+    assert!(payload.is_complete());
+}
+
+#[test]
+fn test_pes_packet_payload_clear() {
+    let mut payload = PesPacketPayload::new();
+    payload.append(&[1, 2, 3]);
+    payload.set_completable(true);
+    payload.set_packet_length(100);
+
+    payload.clear();
+    assert!(payload.is_empty());
+    assert!(!payload.is_completable());
+    assert_eq!(payload.get_packet_length(), 0);
+}
+
+#[test]
+fn test_pes_buffer_new() {
+    let buffer = PesBuffer::new();
+    assert!(buffer.payload.is_empty());
+}
+
+#[test]
+fn test_pes_buffer_add_fragment_without_payload() {
+    let mut buffer = PesBuffer::new();
+    let fragment = MpegtsFragment {
+        header: Header::default(),
+        adaptation_field: None,
+        payload: None,
+    };
+    buffer.add_fragment(&fragment);
+    assert!(buffer.payload.is_empty());
+}
+
+#[test]
+fn test_pes_buffer_add_fragment_with_start() {
+    let mut buffer = PesBuffer::new();
+    let mut header = Header::default();
+    header.payload_unit_start_indicator = true;
+
+    // Create minimal valid PES packet header
+    let pes_data = vec![
+        0x00, 0x00, 0x01, 0xE0, 0x00, 0x04, 0x80, 0x00, 0x00, 1, 2, 3, 4,
+    ];
+
+    let fragment = MpegtsFragment {
+        header,
+        adaptation_field: None,
+        payload: Some(RawPayload { data: pes_data }),
+    };
+
+    buffer.add_fragment(&fragment);
+    assert!(!buffer.payload.is_empty());
+    assert!(buffer.payload.is_completable());
+}
+
+#[test]
+fn test_pes_buffer_add_fragment_continuation() {
+    let mut buffer = PesBuffer::new();
+
+    // First fragment with start
+    let mut header = Header::default();
+    header.payload_unit_start_indicator = true;
+    let pes_data = vec![0x00, 0x00, 0x01, 0xE0, 0x00, 0x08, 0x80, 0x00, 0x00, 1, 2];
+
+    let fragment = MpegtsFragment {
+        header,
+        adaptation_field: None,
+        payload: Some(RawPayload { data: pes_data }),
+    };
+    buffer.add_fragment(&fragment);
+
+    // Continuation fragment
+    let header = Header::default();
+    let continuation_data = vec![3, 4, 5, 6, 7, 8];
+    let fragment = MpegtsFragment {
+        header,
+        adaptation_field: None,
+        payload: Some(RawPayload {
+            data: continuation_data,
+        }),
+    };
+    buffer.add_fragment(&fragment);
+    assert_eq!(buffer.payload.get_data().len(), 17);
+}
+
+#[test]
+fn test_pes_buffer_build_incomplete() {
+    let mut buffer = PesBuffer::new();
+    assert!(buffer.build().is_none());
+}


### PR DESCRIPTION
This pull request includes significant changes to the MPEG-TS packet processing, particularly focusing on the handling of PES (Packetized Elementary Stream) packets. The most important changes include the addition of new methods for handling PES packets, modifications to existing structures to support these new methods, and the removal of obsolete code.

Enhancements to PES packet handling:

* [`common/src/mpegts/aggregator.rs`](diffhunk://#diff-44fb13818ef2a686bd465d838712eec5b5798437d3760b65ab2d6ae8cb6a3150R56-R69): Added methods `add_pes` and `get_pes` to `MpegtsAggregator` to manage PES packets. [[1]](diffhunk://#diff-44fb13818ef2a686bd465d838712eec5b5798437d3760b65ab2d6ae8cb6a3150R56-R69) [[2]](diffhunk://#diff-44fb13818ef2a686bd465d838712eec5b5798437d3760b65ab2d6ae8cb6a3150R94-R107)
* [`common/src/mpegts/pes.rs`](diffhunk://#diff-c664b3be0a26f510594a15350a118182c471885a11b9797cea02705eab54dd4bL17-R28): Introduced a new `RequiredFields` struct and updated `PacketizedElementaryStream` to use this struct. Added `unmarshall_required_fields` method. [[1]](diffhunk://#diff-c664b3be0a26f510594a15350a118182c471885a11b9797cea02705eab54dd4bL17-R28) [[2]](diffhunk://#diff-c664b3be0a26f510594a15350a118182c471885a11b9797cea02705eab54dd4bL38-R46) [[3]](diffhunk://#diff-c664b3be0a26f510594a15350a118182c471885a11b9797cea02705eab54dd4bR57-R74)

Code simplification and cleanup:

* [`common/src/mpegts/pes/pes_buffer.rs`](diffhunk://#diff-e5fe0aab8aa3232499bdfdc740a205dc687feb232082058c83acf3950b5fd967L1-R129): Refactored `PesBuffer` to use a single `PesPacketPayload` instead of a `HashMap`. Added methods to manage PES packet payloads and their completeness.
* [`common/src/mpegts/pes/fragmentary_pes.rs`](diffhunk://#diff-d5b1dbf71fdd9105c781d5bfddf2c3f320e1a0a144b035adb850045554016df4L1-L8): Removed the `FragmentaryPes` struct as it is no longer needed.
* [`common/src/mpegts/pes.rs`](diffhunk://#diff-c664b3be0a26f510594a15350a118182c471885a11b9797cea02705eab54dd4bL3): Removed the unused `fragmentary_pes` module.

Testing improvements:

* [`common/src/mpegts/pes/pes_buffer/tests.rs`](diffhunk://#diff-aeb419bdf8e5a543c72ed3beb6be4956ebdfedcf17e7169b3750bdfb22fda28aR1-R139): Added comprehensive tests for the new PES packet handling logic in `PesBuffer`.